### PR TITLE
add cloudfront.net

### DIFF
--- a/domains
+++ b/domains
@@ -53,3 +53,4 @@
 .maven.org
 .jitpack.io
 .maven.google.com
+.cloudfront.net


### PR DESCRIPTION
```bash
$ docker pull alpine
Using default tag: latest
latest: Pulling from library/alpine
43d680a959df: Pulling fs layer
error pulling image configuration: Get https://dseasb33srnrn.cloudfront.net/registry-v2/docker/registry/v2/blobs/sha256/66/665ffb03bfaea7d8b7472edc0a741b429267db249b1fcead457886e861eae25f/data?Expires=1497957957&Signature=hMt4wby3L1ZpuQ8B3AfAvWGPnUNow7CvmJXT83GDW0kw5NLEkrnNFq0ZF82zjBZ8MHSp0CHgtUIL000DBYuFIEUIWBkhKmySouxT8zT2DtgpkKVnTuZUGx~2E6Ydd217OEwE9dxOC9YhaMvLb4efa0Ox5Jr5XjIqKlLTRG2Xvpk_&Key-Pair-Id=APKAJECH5M7VWIS5YZ6Q: Request blocked by Privoxy
```

It seems that Docker is using Amazon CloudFront for serving images. I'm not sure if it's a good call to support whole CloudFront.