### PR TITLE
Update domains

### DIFF
--- a/domains
+++ b/domains
@@ -55,3 +55,4 @@
 .maven.google.com
 .cloudfront.net
 .nvidia.com
+.rstudio.com


### PR DESCRIPTION
RStudio is the most famous IDE for R language. please add it's blocked domain.
Thanks.