### PR TITLE
adding unity.com

### DIFF
--- a/domains
+++ b/domains
@@ -8,6 +8,7 @@
 .appengine.google.com
 .google.ai
 .unity3d.com
+.unity.com
 .cloud.google.com
 .analytics.google.com
 .fiber.google.com


### PR DESCRIPTION
Some unity links like forum first go to api.unity.com and then became redirected to forum.unity3d.com again