### PR TITLE
Add releases.hashicorp.com to domains

### DIFF
--- a/domains
+++ b/domains
@@ -97,3 +97,4 @@
 .code.google.com
 .maas.io
 .docs.datastax.com
+.releases.hashicorp.com


### PR DESCRIPTION
We cannot download any of open source tools by Hashicorp. One example is downloading Vagrant from https://www.vagrantup.com/downloads.html