### PR TITLE
Add livefyre.com

### DIFF
--- a/domains
+++ b/domains
@@ -103,3 +103,4 @@
 .docs.datastax.com
 .releases.hashicorp.com
 .tinyjpg.com
+.livefyre.com


### PR DESCRIPTION
Please consider adding livefyre.com. This is an Adobe product which its [sub-domain](https://identity.livefyre.com/microsoft.fyre.co/pages/profile/) is mainly used on https://docs.microsoft.com for commenting & asking questions.